### PR TITLE
Slight error in accelerator

### DIFF
--- a/driver.py
+++ b/driver.py
@@ -128,7 +128,7 @@ def main():
             with accelerator.accumulate(model):
                 loss = diffusion(mask, img)
                 accelerator.log({'loss': loss}) # Log loss to wandb
-                loss.backward()
+                accelerator.backward(loss)
                 optimizer.step()
                 optimizer.zero_grad()
         running_loss += loss.item() * img.size(0)


### PR DESCRIPTION
Sorry, found a slight bug where I did 
```
loss.backward() 
```
instead of 
```
accelerator.backward(loss)
```